### PR TITLE
Remove enemy_hurt from bari mixin on_hurt_by_sword()

### DIFF
--- a/data/enemies/bari_mixin.lua
+++ b/data/enemies/bari_mixin.lua
@@ -45,8 +45,6 @@ function bari_mixin.mixin(enemy)
         if self:is_shocking() then
             hero:start_electrocution(500, self:get_damage())
         else
-            -- Why doesn't hurt() remove life?
-            self:hurt(game:get_ability('sword'))
             self:remove_life(game:get_ability('sword'))
         end
     end


### PR DESCRIPTION
self:hurt should not be used here since the enemy is already in the hurt state.
