### PR TITLE
Show some debug info in the menu

### DIFF
--- a/data/lib/zentropy.lua
+++ b/data/lib/zentropy.lua
@@ -15,6 +15,7 @@ local condition_manager = require 'lib/hero_condition'
 bit32 = bit32 or bit
 
 zentropy = zentropy or {
+    version = "0.2",
     db = {
         Project = {},
         Components = Class:new{
@@ -586,6 +587,14 @@ function zentropy.Room:sign(data)
     zentropy.debug(util.ijoin("\n", data))
     self.data_messages('error', 'cannot fit sign')
     return true
+end
+
+function zentropy.game.get_tier()
+    return zentropy.game.game:get_value('tier')
+end
+
+function zentropy.game.get_seed()
+    return zentropy.game.game:get_value('seed')
 end
 
 function zentropy.game.get_items_sequence(rng)

--- a/data/menus/menu.lua
+++ b/data/menus/menu.lua
@@ -35,6 +35,16 @@ function Menu:on_started()
         surface:set_xy(center_x, start_y)
         start_y = start_y + math.ceil(1.5 * item_height)
     end
+
+    local zentropy = require 'lib/zentropy'
+    self.debug = sol.text_surface.create{
+        font = "la",
+        horizontal_alignment = "left",
+        vertical_alignment = "bottom",
+        text = "S:" .. zentropy.game:get_seed() .. " T:" .. zentropy.game:get_tier() .. " V:" .. zentropy.version,
+    }
+    self.debug:set_xy(3, 240)
+    self.debug:set_color{64, 64, 64}
 end
 
 function Menu:on_command_pressed(command)
@@ -67,6 +77,7 @@ function Menu:on_draw(dst_surface)
         end
         surface:draw(dst_surface)
     end
+    self.debug:draw(dst_surface)
 end
 
 function Menu:on_finished()


### PR DESCRIPTION
I put the info in the pause menu instead of the map/inventory menus. It should be easier to find and less distracting that way. I included the Tunics! version per your request. Solarus does not yet provide an API for querying its version, but it's implemented for Solarus 1.5 (christopho/solarus#767). Feel free to open a new issue for the Solarus version number.

Fixes #69.
