### PR TITLE
Use low_wall ground type for barriers

### DIFF
--- a/data/tilesets/dungeon_brick_blue_1.dat
+++ b/data/tilesets/dungeon_brick_blue_1.dat
@@ -101,7 +101,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 40,
@@ -111,7 +111,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 40,
@@ -121,7 +121,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 40,
@@ -131,7 +131,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 88,
@@ -141,7 +141,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 88,
@@ -151,7 +151,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 88,
@@ -161,7 +161,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 80,
@@ -171,7 +171,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 80,
@@ -181,7 +181,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 80,
@@ -2100,86 +2100,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "floor.2",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 112,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.3",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 128,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.4",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 144,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.5",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 160,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.6",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 176,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.7",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 192,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.8",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 208,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.9",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 224,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
   id = "floor.10",
   ground = "traversable",
   default_layer = 1,
@@ -2275,6 +2195,16 @@ tile_pattern{
   default_layer = 1,
   x = 112,
   y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.2",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 112,
   width = 16,
   height = 16,
 }
@@ -2380,6 +2310,16 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "floor.3",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 128,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
   id = "floor.31",
   ground = "traversable",
   default_layer = 1,
@@ -2424,6 +2364,66 @@ tile_pattern{
   ground = "traversable",
   default_layer = 1,
   x = 240,
+  y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.4",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 144,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.5",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 160,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.6",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 176,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.7",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 192,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.8",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 208,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.9",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
   y = 224,
   width = 16,
   height = 16,
@@ -2560,86 +2560,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "floor_low.2",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 112,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.3",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 128,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.4",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 144,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.5",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 160,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.6",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 176,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.7",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 192,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.8",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 208,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.9",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 224,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
   id = "floor_low.10",
   ground = "traversable",
   default_layer = 0,
@@ -2730,6 +2650,16 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "floor_low.2",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 112,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
   id = "floor_low.25",
   ground = "traversable",
   default_layer = 1,
@@ -2774,6 +2704,16 @@ tile_pattern{
   ground = "traversable",
   default_layer = 0,
   x = 256,
+  y = 128,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.3",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
   y = 128,
   width = 16,
   height = 16,
@@ -2834,6 +2774,66 @@ tile_pattern{
   ground = "traversable",
   default_layer = 0,
   x = 256,
+  y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.4",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 144,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.5",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 160,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.6",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 176,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.7",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 192,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.8",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 208,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.9",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
   y = 224,
   width = 16,
   height = 16,
@@ -4147,6 +4147,26 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "table.10",
+  ground = "wall",
+  default_layer = 1,
+  x = 440,
+  y = 112,
+  width = 8,
+  height = 8,
+}
+
+tile_pattern{
+  id = "table.11",
+  ground = "wall",
+  default_layer = 1,
+  x = 456,
+  y = 112,
+  width = 8,
+  height = 8,
+}
+
+tile_pattern{
   id = "table.2",
   ground = "wall",
   default_layer = 1,
@@ -4221,26 +4241,6 @@ tile_pattern{
   ground = "wall",
   default_layer = 1,
   x = 432,
-  y = 112,
-  width = 8,
-  height = 8,
-}
-
-tile_pattern{
-  id = "table.10",
-  ground = "wall",
-  default_layer = 1,
-  x = 440,
-  y = 112,
-  width = 8,
-  height = 8,
-}
-
-tile_pattern{
-  id = "table.11",
-  ground = "wall",
-  default_layer = 1,
-  x = 456,
   y = 112,
   width = 8,
   height = 8,
@@ -5157,6 +5157,46 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "wall_pillar.10.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 432,
+  width = 16,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 224,
+  y = 432,
+  width = 16,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 480,
+  width = 32,
+  height = 16,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 464,
+  width = 32,
+  height = 16,
+}
+
+tile_pattern{
   id = "wall_pillar.2.1",
   ground = "wall",
   default_layer = 1,
@@ -5477,46 +5517,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "wall_pillar.10.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 432,
-  width = 16,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 224,
-  y = 432,
-  width = 16,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 480,
-  width = 32,
-  height = 16,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 464,
-  width = 32,
-  height = 16,
-}
-
-tile_pattern{
   id = "wall_pipe.1",
   ground = "wall",
   default_layer = 1,
@@ -5592,6 +5592,86 @@ tile_pattern{
   default_layer = 1,
   x = 272,
   y = 240,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.10.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 352,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.10.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 320,
+  y = 384,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.10.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 376,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.10.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 328,
+  y = 352,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.11.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 408,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.11.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 320,
+  y = 440,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.11.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 432,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.11.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 328,
+  y = 408,
   width = 24,
   height = 32,
 }
@@ -5912,86 +5992,6 @@ tile_pattern{
   default_layer = 1,
   x = 328,
   y = 296,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.10.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 352,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.10.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 320,
-  y = 384,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.10.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 376,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.10.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 328,
-  y = 352,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.11.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 408,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.11.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 320,
-  y = 440,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.11.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 432,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.11.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 328,
-  y = 408,
   width = 24,
   height = 32,
 }

--- a/data/tilesets/dungeon_brick_brown_1.dat
+++ b/data/tilesets/dungeon_brick_brown_1.dat
@@ -101,7 +101,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 40,
@@ -111,7 +111,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 40,
@@ -121,7 +121,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 40,
@@ -131,7 +131,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 88,
@@ -141,7 +141,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 88,
@@ -151,7 +151,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 88,
@@ -161,7 +161,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 80,
@@ -171,7 +171,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 80,
@@ -181,7 +181,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 80,
@@ -2100,86 +2100,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "floor.2",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 112,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.3",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 128,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.4",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 144,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.5",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 160,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.6",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 176,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.7",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 192,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.8",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 208,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.9",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 224,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
   id = "floor.10",
   ground = "traversable",
   default_layer = 1,
@@ -2275,6 +2195,16 @@ tile_pattern{
   default_layer = 1,
   x = 112,
   y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.2",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 112,
   width = 16,
   height = 16,
 }
@@ -2380,6 +2310,16 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "floor.3",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 128,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
   id = "floor.31",
   ground = "traversable",
   default_layer = 1,
@@ -2424,6 +2364,66 @@ tile_pattern{
   ground = "traversable",
   default_layer = 1,
   x = 240,
+  y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.4",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 144,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.5",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 160,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.6",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 176,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.7",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 192,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.8",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 208,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.9",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
   y = 224,
   width = 16,
   height = 16,
@@ -2560,86 +2560,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "floor_low.2",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 112,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.3",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 128,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.4",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 144,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.5",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 160,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.6",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 176,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.7",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 192,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.8",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 208,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.9",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 224,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
   id = "floor_low.10",
   ground = "traversable",
   default_layer = 0,
@@ -2730,6 +2650,16 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "floor_low.2",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 112,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
   id = "floor_low.25",
   ground = "traversable",
   default_layer = 1,
@@ -2774,6 +2704,16 @@ tile_pattern{
   ground = "traversable",
   default_layer = 0,
   x = 256,
+  y = 128,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.3",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
   y = 128,
   width = 16,
   height = 16,
@@ -2834,6 +2774,66 @@ tile_pattern{
   ground = "traversable",
   default_layer = 0,
   x = 256,
+  y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.4",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 144,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.5",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 160,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.6",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 176,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.7",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 192,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.8",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 208,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.9",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
   y = 224,
   width = 16,
   height = 16,
@@ -4147,6 +4147,26 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "table.10",
+  ground = "wall",
+  default_layer = 1,
+  x = 440,
+  y = 112,
+  width = 8,
+  height = 8,
+}
+
+tile_pattern{
+  id = "table.11",
+  ground = "wall",
+  default_layer = 1,
+  x = 456,
+  y = 112,
+  width = 8,
+  height = 8,
+}
+
+tile_pattern{
   id = "table.2",
   ground = "wall",
   default_layer = 1,
@@ -4221,26 +4241,6 @@ tile_pattern{
   ground = "wall",
   default_layer = 1,
   x = 432,
-  y = 112,
-  width = 8,
-  height = 8,
-}
-
-tile_pattern{
-  id = "table.10",
-  ground = "wall",
-  default_layer = 1,
-  x = 440,
-  y = 112,
-  width = 8,
-  height = 8,
-}
-
-tile_pattern{
-  id = "table.11",
-  ground = "wall",
-  default_layer = 1,
-  x = 456,
   y = 112,
   width = 8,
   height = 8,
@@ -5157,6 +5157,46 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "wall_pillar.10.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 432,
+  width = 16,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 224,
+  y = 432,
+  width = 16,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 480,
+  width = 32,
+  height = 16,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 464,
+  width = 32,
+  height = 16,
+}
+
+tile_pattern{
   id = "wall_pillar.2.1",
   ground = "wall",
   default_layer = 1,
@@ -5477,46 +5517,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "wall_pillar.10.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 432,
-  width = 16,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 224,
-  y = 432,
-  width = 16,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 480,
-  width = 32,
-  height = 16,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 464,
-  width = 32,
-  height = 16,
-}
-
-tile_pattern{
   id = "wall_pipe.1",
   ground = "wall",
   default_layer = 1,
@@ -5592,6 +5592,86 @@ tile_pattern{
   default_layer = 1,
   x = 272,
   y = 240,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.10.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 352,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.10.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 320,
+  y = 384,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.10.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 376,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.10.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 328,
+  y = 352,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.11.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 408,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.11.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 320,
+  y = 440,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.11.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 432,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.11.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 328,
+  y = 408,
   width = 24,
   height = 32,
 }
@@ -5912,86 +5992,6 @@ tile_pattern{
   default_layer = 1,
   x = 328,
   y = 296,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.10.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 352,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.10.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 320,
-  y = 384,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.10.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 376,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.10.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 328,
-  y = 352,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.11.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 408,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.11.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 320,
-  y = 440,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.11.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 432,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.11.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 328,
-  y = 408,
   width = 24,
   height = 32,
 }

--- a/data/tilesets/dungeon_brick_gray_1.dat
+++ b/data/tilesets/dungeon_brick_gray_1.dat
@@ -101,7 +101,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 40,
@@ -111,7 +111,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 40,
@@ -121,7 +121,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 40,
@@ -131,7 +131,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 88,
@@ -141,7 +141,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 88,
@@ -151,7 +151,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 88,
@@ -161,7 +161,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 80,
@@ -171,7 +171,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 80,
@@ -181,7 +181,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 80,
@@ -2100,86 +2100,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "floor.2",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 112,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.3",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 128,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.4",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 144,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.5",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 160,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.6",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 176,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.7",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 192,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.8",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 208,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.9",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 224,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
   id = "floor.10",
   ground = "traversable",
   default_layer = 1,
@@ -2275,6 +2195,16 @@ tile_pattern{
   default_layer = 1,
   x = 112,
   y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.2",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 112,
   width = 16,
   height = 16,
 }
@@ -2380,6 +2310,16 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "floor.3",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 128,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
   id = "floor.31",
   ground = "traversable",
   default_layer = 1,
@@ -2424,6 +2364,66 @@ tile_pattern{
   ground = "traversable",
   default_layer = 1,
   x = 240,
+  y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.4",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 144,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.5",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 160,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.6",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 176,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.7",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 192,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.8",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 208,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.9",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
   y = 224,
   width = 16,
   height = 16,
@@ -2560,86 +2560,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "floor_low.2",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 112,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.3",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 128,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.4",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 144,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.5",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 160,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.6",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 176,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.7",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 192,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.8",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 208,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.9",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 224,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
   id = "floor_low.10",
   ground = "traversable",
   default_layer = 0,
@@ -2730,6 +2650,16 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "floor_low.2",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 112,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
   id = "floor_low.25",
   ground = "traversable",
   default_layer = 1,
@@ -2774,6 +2704,16 @@ tile_pattern{
   ground = "traversable",
   default_layer = 0,
   x = 256,
+  y = 128,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.3",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
   y = 128,
   width = 16,
   height = 16,
@@ -2834,6 +2774,66 @@ tile_pattern{
   ground = "traversable",
   default_layer = 0,
   x = 256,
+  y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.4",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 144,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.5",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 160,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.6",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 176,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.7",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 192,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.8",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 208,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.9",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
   y = 224,
   width = 16,
   height = 16,
@@ -4147,6 +4147,26 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "table.10",
+  ground = "wall",
+  default_layer = 1,
+  x = 440,
+  y = 112,
+  width = 8,
+  height = 8,
+}
+
+tile_pattern{
+  id = "table.11",
+  ground = "wall",
+  default_layer = 1,
+  x = 456,
+  y = 112,
+  width = 8,
+  height = 8,
+}
+
+tile_pattern{
   id = "table.2",
   ground = "wall",
   default_layer = 1,
@@ -4221,26 +4241,6 @@ tile_pattern{
   ground = "wall",
   default_layer = 1,
   x = 432,
-  y = 112,
-  width = 8,
-  height = 8,
-}
-
-tile_pattern{
-  id = "table.10",
-  ground = "wall",
-  default_layer = 1,
-  x = 440,
-  y = 112,
-  width = 8,
-  height = 8,
-}
-
-tile_pattern{
-  id = "table.11",
-  ground = "wall",
-  default_layer = 1,
-  x = 456,
   y = 112,
   width = 8,
   height = 8,
@@ -5157,6 +5157,46 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "wall_pillar.10.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 432,
+  width = 16,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 224,
+  y = 432,
+  width = 16,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 480,
+  width = 32,
+  height = 16,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 464,
+  width = 32,
+  height = 16,
+}
+
+tile_pattern{
   id = "wall_pillar.2.1",
   ground = "wall",
   default_layer = 1,
@@ -5477,46 +5517,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "wall_pillar.10.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 432,
-  width = 16,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 224,
-  y = 432,
-  width = 16,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 480,
-  width = 32,
-  height = 16,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 464,
-  width = 32,
-  height = 16,
-}
-
-tile_pattern{
   id = "wall_pipe.1",
   ground = "wall",
   default_layer = 1,
@@ -5592,6 +5592,86 @@ tile_pattern{
   default_layer = 1,
   x = 272,
   y = 240,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.10.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 352,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.10.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 320,
+  y = 384,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.10.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 376,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.10.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 328,
+  y = 352,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.11.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 408,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.11.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 320,
+  y = 440,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.11.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 432,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.11.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 328,
+  y = 408,
   width = 24,
   height = 32,
 }
@@ -5912,86 +5992,6 @@ tile_pattern{
   default_layer = 1,
   x = 328,
   y = 296,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.10.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 352,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.10.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 320,
-  y = 384,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.10.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 376,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.10.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 328,
-  y = 352,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.11.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 408,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.11.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 320,
-  y = 440,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.11.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 432,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.11.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 328,
-  y = 408,
   width = 24,
   height = 32,
 }

--- a/data/tilesets/dungeon_brick_gray_2.dat
+++ b/data/tilesets/dungeon_brick_gray_2.dat
@@ -101,7 +101,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 40,
@@ -111,7 +111,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 40,
@@ -121,7 +121,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 40,
@@ -131,7 +131,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 88,
@@ -141,7 +141,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 88,
@@ -151,7 +151,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 88,
@@ -161,7 +161,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 80,
@@ -171,7 +171,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 80,
@@ -181,7 +181,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 80,
@@ -2100,86 +2100,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "floor.2",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 112,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.3",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 128,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.4",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 144,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.5",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 160,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.6",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 176,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.7",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 192,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.8",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 208,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.9",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 224,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
   id = "floor.10",
   ground = "traversable",
   default_layer = 1,
@@ -2275,6 +2195,16 @@ tile_pattern{
   default_layer = 1,
   x = 112,
   y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.2",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 112,
   width = 16,
   height = 16,
 }
@@ -2380,6 +2310,16 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "floor.3",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 128,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
   id = "floor.31",
   ground = "traversable",
   default_layer = 1,
@@ -2424,6 +2364,66 @@ tile_pattern{
   ground = "traversable",
   default_layer = 1,
   x = 240,
+  y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.4",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 144,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.5",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 160,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.6",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 176,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.7",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 192,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.8",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 208,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.9",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
   y = 224,
   width = 16,
   height = 16,
@@ -2560,86 +2560,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "floor_low.2",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 112,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.3",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 128,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.4",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 144,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.5",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 160,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.6",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 176,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.7",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 192,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.8",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 208,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.9",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 224,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
   id = "floor_low.10",
   ground = "traversable",
   default_layer = 0,
@@ -2730,6 +2650,16 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "floor_low.2",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 112,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
   id = "floor_low.25",
   ground = "traversable",
   default_layer = 1,
@@ -2774,6 +2704,16 @@ tile_pattern{
   ground = "traversable",
   default_layer = 0,
   x = 256,
+  y = 128,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.3",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
   y = 128,
   width = 16,
   height = 16,
@@ -2834,6 +2774,66 @@ tile_pattern{
   ground = "traversable",
   default_layer = 0,
   x = 256,
+  y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.4",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 144,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.5",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 160,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.6",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 176,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.7",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 192,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.8",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 208,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.9",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
   y = 224,
   width = 16,
   height = 16,
@@ -4147,6 +4147,26 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "table.10",
+  ground = "wall",
+  default_layer = 1,
+  x = 440,
+  y = 112,
+  width = 8,
+  height = 8,
+}
+
+tile_pattern{
+  id = "table.11",
+  ground = "wall",
+  default_layer = 1,
+  x = 456,
+  y = 112,
+  width = 8,
+  height = 8,
+}
+
+tile_pattern{
   id = "table.2",
   ground = "wall",
   default_layer = 1,
@@ -4221,26 +4241,6 @@ tile_pattern{
   ground = "wall",
   default_layer = 1,
   x = 432,
-  y = 112,
-  width = 8,
-  height = 8,
-}
-
-tile_pattern{
-  id = "table.10",
-  ground = "wall",
-  default_layer = 1,
-  x = 440,
-  y = 112,
-  width = 8,
-  height = 8,
-}
-
-tile_pattern{
-  id = "table.11",
-  ground = "wall",
-  default_layer = 1,
-  x = 456,
   y = 112,
   width = 8,
   height = 8,
@@ -5157,6 +5157,46 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "wall_pillar.10.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 432,
+  width = 16,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 224,
+  y = 432,
+  width = 16,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 480,
+  width = 32,
+  height = 16,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 464,
+  width = 32,
+  height = 16,
+}
+
+tile_pattern{
   id = "wall_pillar.2.1",
   ground = "wall",
   default_layer = 1,
@@ -5477,46 +5517,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "wall_pillar.10.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 432,
-  width = 16,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 224,
-  y = 432,
-  width = 16,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 480,
-  width = 32,
-  height = 16,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 464,
-  width = 32,
-  height = 16,
-}
-
-tile_pattern{
   id = "wall_pipe.1",
   ground = "wall",
   default_layer = 1,
@@ -5592,6 +5592,86 @@ tile_pattern{
   default_layer = 1,
   x = 272,
   y = 240,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.10.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 352,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.10.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 320,
+  y = 384,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.10.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 376,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.10.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 328,
+  y = 352,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.11.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 408,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.11.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 320,
+  y = 440,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.11.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 432,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.11.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 328,
+  y = 408,
   width = 24,
   height = 32,
 }
@@ -5912,86 +5992,6 @@ tile_pattern{
   default_layer = 1,
   x = 328,
   y = 296,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.10.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 352,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.10.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 320,
-  y = 384,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.10.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 376,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.10.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 328,
-  y = 352,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.11.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 408,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.11.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 320,
-  y = 440,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.11.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 432,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.11.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 328,
-  y = 408,
   width = 24,
   height = 32,
 }

--- a/data/tilesets/dungeon_brick_green_1.dat
+++ b/data/tilesets/dungeon_brick_green_1.dat
@@ -101,7 +101,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 40,
@@ -111,7 +111,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 40,
@@ -121,7 +121,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 40,
@@ -131,7 +131,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 88,
@@ -141,7 +141,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 88,
@@ -151,7 +151,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 88,
@@ -161,7 +161,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 80,
@@ -171,7 +171,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 80,
@@ -181,7 +181,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 80,
@@ -2100,86 +2100,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "floor.2",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 112,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.3",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 128,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.4",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 144,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.5",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 160,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.6",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 176,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.7",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 192,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.8",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 208,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.9",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 224,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
   id = "floor.10",
   ground = "traversable",
   default_layer = 1,
@@ -2275,6 +2195,16 @@ tile_pattern{
   default_layer = 1,
   x = 112,
   y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.2",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 112,
   width = 16,
   height = 16,
 }
@@ -2380,6 +2310,16 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "floor.3",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 128,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
   id = "floor.31",
   ground = "traversable",
   default_layer = 1,
@@ -2424,6 +2364,66 @@ tile_pattern{
   ground = "traversable",
   default_layer = 1,
   x = 240,
+  y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.4",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 144,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.5",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 160,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.6",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 176,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.7",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 192,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.8",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 208,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.9",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
   y = 224,
   width = 16,
   height = 16,
@@ -2560,86 +2560,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "floor_low.2",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 112,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.3",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 128,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.4",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 144,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.5",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 160,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.6",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 176,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.7",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 192,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.8",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 208,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.9",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 224,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
   id = "floor_low.10",
   ground = "traversable",
   default_layer = 0,
@@ -2730,6 +2650,16 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "floor_low.2",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 112,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
   id = "floor_low.25",
   ground = "traversable",
   default_layer = 1,
@@ -2774,6 +2704,16 @@ tile_pattern{
   ground = "traversable",
   default_layer = 0,
   x = 256,
+  y = 128,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.3",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
   y = 128,
   width = 16,
   height = 16,
@@ -2834,6 +2774,66 @@ tile_pattern{
   ground = "traversable",
   default_layer = 0,
   x = 256,
+  y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.4",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 144,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.5",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 160,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.6",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 176,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.7",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 192,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.8",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 208,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.9",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
   y = 224,
   width = 16,
   height = 16,
@@ -4147,6 +4147,26 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "table.10",
+  ground = "wall",
+  default_layer = 1,
+  x = 440,
+  y = 112,
+  width = 8,
+  height = 8,
+}
+
+tile_pattern{
+  id = "table.11",
+  ground = "wall",
+  default_layer = 1,
+  x = 456,
+  y = 112,
+  width = 8,
+  height = 8,
+}
+
+tile_pattern{
   id = "table.2",
   ground = "wall",
   default_layer = 1,
@@ -4221,26 +4241,6 @@ tile_pattern{
   ground = "wall",
   default_layer = 1,
   x = 432,
-  y = 112,
-  width = 8,
-  height = 8,
-}
-
-tile_pattern{
-  id = "table.10",
-  ground = "wall",
-  default_layer = 1,
-  x = 440,
-  y = 112,
-  width = 8,
-  height = 8,
-}
-
-tile_pattern{
-  id = "table.11",
-  ground = "wall",
-  default_layer = 1,
-  x = 456,
   y = 112,
   width = 8,
   height = 8,
@@ -5157,6 +5157,46 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "wall_pillar.10.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 432,
+  width = 16,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 224,
+  y = 432,
+  width = 16,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 480,
+  width = 32,
+  height = 16,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 464,
+  width = 32,
+  height = 16,
+}
+
+tile_pattern{
   id = "wall_pillar.2.1",
   ground = "wall",
   default_layer = 1,
@@ -5477,46 +5517,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "wall_pillar.10.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 432,
-  width = 16,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 224,
-  y = 432,
-  width = 16,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 480,
-  width = 32,
-  height = 16,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 464,
-  width = 32,
-  height = 16,
-}
-
-tile_pattern{
   id = "wall_pipe.1",
   ground = "wall",
   default_layer = 1,
@@ -5592,6 +5592,86 @@ tile_pattern{
   default_layer = 1,
   x = 272,
   y = 240,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.10.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 352,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.10.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 320,
+  y = 384,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.10.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 376,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.10.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 328,
+  y = 352,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.11.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 408,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.11.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 320,
+  y = 440,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.11.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 432,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.11.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 328,
+  y = 408,
   width = 24,
   height = 32,
 }
@@ -5912,86 +5992,6 @@ tile_pattern{
   default_layer = 1,
   x = 328,
   y = 296,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.10.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 352,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.10.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 320,
-  y = 384,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.10.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 376,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.10.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 328,
-  y = 352,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.11.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 408,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.11.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 320,
-  y = 440,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.11.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 432,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.11.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 328,
-  y = 408,
   width = 24,
   height = 32,
 }

--- a/data/tilesets/dungeon_cave_brown_1.dat
+++ b/data/tilesets/dungeon_cave_brown_1.dat
@@ -101,7 +101,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 40,
@@ -111,7 +111,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 40,
@@ -121,7 +121,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 40,
@@ -131,7 +131,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 88,
@@ -141,7 +141,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 88,
@@ -151,7 +151,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 88,
@@ -161,7 +161,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 80,
@@ -171,7 +171,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 80,
@@ -181,7 +181,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 80,
@@ -2100,86 +2100,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "floor.2",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 112,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.3",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 128,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.4",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 144,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.5",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 160,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.6",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 176,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.7",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 192,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.8",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 208,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.9",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 224,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
   id = "floor.10",
   ground = "traversable",
   default_layer = 1,
@@ -2275,6 +2195,16 @@ tile_pattern{
   default_layer = 1,
   x = 112,
   y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.2",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 112,
   width = 16,
   height = 16,
 }
@@ -2380,6 +2310,16 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "floor.3",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 128,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
   id = "floor.31",
   ground = "traversable",
   default_layer = 1,
@@ -2424,6 +2364,66 @@ tile_pattern{
   ground = "traversable",
   default_layer = 1,
   x = 240,
+  y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.4",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 144,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.5",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 160,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.6",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 176,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.7",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 192,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.8",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 208,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.9",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
   y = 224,
   width = 16,
   height = 16,
@@ -2560,86 +2560,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "floor_low.2",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 112,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.3",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 128,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.4",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 144,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.5",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 160,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.6",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 176,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.7",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 192,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.8",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 208,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.9",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 224,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
   id = "floor_low.10",
   ground = "traversable",
   default_layer = 0,
@@ -2730,6 +2650,16 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "floor_low.2",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 112,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
   id = "floor_low.25",
   ground = "traversable",
   default_layer = 1,
@@ -2774,6 +2704,16 @@ tile_pattern{
   ground = "traversable",
   default_layer = 0,
   x = 256,
+  y = 128,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.3",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
   y = 128,
   width = 16,
   height = 16,
@@ -2834,6 +2774,66 @@ tile_pattern{
   ground = "traversable",
   default_layer = 0,
   x = 256,
+  y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.4",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 144,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.5",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 160,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.6",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 176,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.7",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 192,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.8",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 208,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.9",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
   y = 224,
   width = 16,
   height = 16,
@@ -4147,6 +4147,26 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "table.10",
+  ground = "wall",
+  default_layer = 1,
+  x = 440,
+  y = 112,
+  width = 8,
+  height = 8,
+}
+
+tile_pattern{
+  id = "table.11",
+  ground = "wall",
+  default_layer = 1,
+  x = 456,
+  y = 112,
+  width = 8,
+  height = 8,
+}
+
+tile_pattern{
   id = "table.2",
   ground = "wall",
   default_layer = 1,
@@ -4221,26 +4241,6 @@ tile_pattern{
   ground = "wall",
   default_layer = 1,
   x = 432,
-  y = 112,
-  width = 8,
-  height = 8,
-}
-
-tile_pattern{
-  id = "table.10",
-  ground = "wall",
-  default_layer = 1,
-  x = 440,
-  y = 112,
-  width = 8,
-  height = 8,
-}
-
-tile_pattern{
-  id = "table.11",
-  ground = "wall",
-  default_layer = 1,
-  x = 456,
   y = 112,
   width = 8,
   height = 8,
@@ -5157,6 +5157,46 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "wall_pillar.10.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 432,
+  width = 16,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 224,
+  y = 432,
+  width = 16,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 480,
+  width = 32,
+  height = 16,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 464,
+  width = 32,
+  height = 16,
+}
+
+tile_pattern{
   id = "wall_pillar.2.1",
   ground = "wall",
   default_layer = 1,
@@ -5477,46 +5517,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "wall_pillar.10.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 432,
-  width = 16,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 224,
-  y = 432,
-  width = 16,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 480,
-  width = 32,
-  height = 16,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 464,
-  width = 32,
-  height = 16,
-}
-
-tile_pattern{
   id = "wall_pipe.1",
   ground = "wall",
   default_layer = 1,
@@ -5592,6 +5592,86 @@ tile_pattern{
   default_layer = 1,
   x = 272,
   y = 240,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.10.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 352,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.10.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 320,
+  y = 384,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.10.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 376,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.10.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 328,
+  y = 352,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.11.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 408,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.11.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 320,
+  y = 440,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.11.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 432,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.11.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 328,
+  y = 408,
   width = 24,
   height = 32,
 }
@@ -5912,86 +5992,6 @@ tile_pattern{
   default_layer = 1,
   x = 328,
   y = 296,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.10.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 352,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.10.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 320,
-  y = 384,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.10.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 376,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.10.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 328,
-  y = 352,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.11.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 408,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.11.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 320,
-  y = 440,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.11.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 432,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.11.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 328,
-  y = 408,
   width = 24,
   height = 32,
 }

--- a/data/tilesets/dungeon_ganon_brown_1.dat
+++ b/data/tilesets/dungeon_ganon_brown_1.dat
@@ -101,7 +101,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 40,
@@ -111,7 +111,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 40,
@@ -121,7 +121,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 40,
@@ -131,7 +131,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 88,
@@ -141,7 +141,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 88,
@@ -151,7 +151,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 88,
@@ -161,7 +161,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 80,
@@ -171,7 +171,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 80,
@@ -181,7 +181,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 80,
@@ -2100,86 +2100,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "floor.2",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 112,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.3",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 128,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.4",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 144,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.5",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 160,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.6",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 176,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.7",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 192,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.8",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 208,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.9",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 224,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
   id = "floor.10",
   ground = "traversable",
   default_layer = 1,
@@ -2275,6 +2195,16 @@ tile_pattern{
   default_layer = 1,
   x = 112,
   y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.2",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 112,
   width = 16,
   height = 16,
 }
@@ -2380,6 +2310,16 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "floor.3",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 128,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
   id = "floor.31",
   ground = "traversable",
   default_layer = 1,
@@ -2424,6 +2364,66 @@ tile_pattern{
   ground = "traversable",
   default_layer = 1,
   x = 240,
+  y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.4",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 144,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.5",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 160,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.6",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 176,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.7",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 192,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.8",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 208,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.9",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
   y = 224,
   width = 16,
   height = 16,
@@ -2560,86 +2560,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "floor_low.2",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 112,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.3",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 128,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.4",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 144,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.5",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 160,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.6",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 176,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.7",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 192,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.8",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 208,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.9",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 224,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
   id = "floor_low.10",
   ground = "traversable",
   default_layer = 0,
@@ -2730,6 +2650,16 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "floor_low.2",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 112,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
   id = "floor_low.25",
   ground = "traversable",
   default_layer = 1,
@@ -2774,6 +2704,16 @@ tile_pattern{
   ground = "traversable",
   default_layer = 0,
   x = 256,
+  y = 128,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.3",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
   y = 128,
   width = 16,
   height = 16,
@@ -2834,6 +2774,66 @@ tile_pattern{
   ground = "traversable",
   default_layer = 0,
   x = 256,
+  y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.4",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 144,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.5",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 160,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.6",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 176,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.7",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 192,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.8",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 208,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.9",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
   y = 224,
   width = 16,
   height = 16,
@@ -4147,6 +4147,26 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "table.10",
+  ground = "wall",
+  default_layer = 1,
+  x = 440,
+  y = 112,
+  width = 8,
+  height = 8,
+}
+
+tile_pattern{
+  id = "table.11",
+  ground = "wall",
+  default_layer = 1,
+  x = 456,
+  y = 112,
+  width = 8,
+  height = 8,
+}
+
+tile_pattern{
   id = "table.2",
   ground = "wall",
   default_layer = 1,
@@ -4221,26 +4241,6 @@ tile_pattern{
   ground = "wall",
   default_layer = 1,
   x = 432,
-  y = 112,
-  width = 8,
-  height = 8,
-}
-
-tile_pattern{
-  id = "table.10",
-  ground = "wall",
-  default_layer = 1,
-  x = 440,
-  y = 112,
-  width = 8,
-  height = 8,
-}
-
-tile_pattern{
-  id = "table.11",
-  ground = "wall",
-  default_layer = 1,
-  x = 456,
   y = 112,
   width = 8,
   height = 8,
@@ -5157,6 +5157,46 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "wall_pillar.10.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 432,
+  width = 16,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 224,
+  y = 432,
+  width = 16,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 480,
+  width = 32,
+  height = 16,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 464,
+  width = 32,
+  height = 16,
+}
+
+tile_pattern{
   id = "wall_pillar.2.1",
   ground = "wall",
   default_layer = 1,
@@ -5477,46 +5517,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "wall_pillar.10.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 432,
-  width = 16,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 224,
-  y = 432,
-  width = 16,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 480,
-  width = 32,
-  height = 16,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 464,
-  width = 32,
-  height = 16,
-}
-
-tile_pattern{
   id = "wall_pipe.1",
   ground = "wall",
   default_layer = 1,
@@ -5592,6 +5592,86 @@ tile_pattern{
   default_layer = 1,
   x = 272,
   y = 240,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.10.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 352,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.10.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 320,
+  y = 384,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.10.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 376,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.10.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 328,
+  y = 352,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.11.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 408,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.11.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 320,
+  y = 440,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.11.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 432,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.11.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 328,
+  y = 408,
   width = 24,
   height = 32,
 }
@@ -5912,86 +5992,6 @@ tile_pattern{
   default_layer = 1,
   x = 328,
   y = 296,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.10.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 352,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.10.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 320,
-  y = 384,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.10.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 376,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.10.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 328,
-  y = 352,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.11.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 408,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.11.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 320,
-  y = 440,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.11.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 432,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.11.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 328,
-  y = 408,
   width = 24,
   height = 32,
 }

--- a/data/tilesets/dungeon_house_brown_1.dat
+++ b/data/tilesets/dungeon_house_brown_1.dat
@@ -101,7 +101,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 40,
@@ -111,7 +111,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 40,
@@ -121,7 +121,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 40,
@@ -131,7 +131,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 88,
@@ -141,7 +141,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 88,
@@ -151,7 +151,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 88,
@@ -161,7 +161,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 80,
@@ -171,7 +171,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 80,
@@ -181,7 +181,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 80,
@@ -2100,86 +2100,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "floor.2",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 112,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.3",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 128,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.4",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 144,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.5",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 160,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.6",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 176,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.7",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 192,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.8",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 208,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.9",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 224,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
   id = "floor.10",
   ground = "traversable",
   default_layer = 1,
@@ -2275,6 +2195,16 @@ tile_pattern{
   default_layer = 1,
   x = 112,
   y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.2",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 112,
   width = 16,
   height = 16,
 }
@@ -2380,6 +2310,16 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "floor.3",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 128,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
   id = "floor.31",
   ground = "traversable",
   default_layer = 1,
@@ -2424,6 +2364,66 @@ tile_pattern{
   ground = "traversable",
   default_layer = 1,
   x = 240,
+  y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.4",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 144,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.5",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 160,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.6",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 176,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.7",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 192,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.8",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 208,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.9",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
   y = 224,
   width = 16,
   height = 16,
@@ -2560,86 +2560,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "floor_low.2",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 112,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.3",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 128,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.4",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 144,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.5",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 160,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.6",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 176,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.7",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 192,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.8",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 208,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.9",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 224,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
   id = "floor_low.10",
   ground = "traversable",
   default_layer = 0,
@@ -2730,6 +2650,16 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "floor_low.2",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 112,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
   id = "floor_low.25",
   ground = "traversable",
   default_layer = 1,
@@ -2774,6 +2704,16 @@ tile_pattern{
   ground = "traversable",
   default_layer = 0,
   x = 256,
+  y = 128,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.3",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
   y = 128,
   width = 16,
   height = 16,
@@ -2834,6 +2774,66 @@ tile_pattern{
   ground = "traversable",
   default_layer = 0,
   x = 256,
+  y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.4",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 144,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.5",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 160,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.6",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 176,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.7",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 192,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.8",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 208,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.9",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
   y = 224,
   width = 16,
   height = 16,
@@ -4147,6 +4147,26 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "table.10",
+  ground = "wall",
+  default_layer = 1,
+  x = 440,
+  y = 112,
+  width = 8,
+  height = 8,
+}
+
+tile_pattern{
+  id = "table.11",
+  ground = "wall",
+  default_layer = 1,
+  x = 456,
+  y = 112,
+  width = 8,
+  height = 8,
+}
+
+tile_pattern{
   id = "table.2",
   ground = "wall",
   default_layer = 1,
@@ -4221,26 +4241,6 @@ tile_pattern{
   ground = "wall",
   default_layer = 1,
   x = 432,
-  y = 112,
-  width = 8,
-  height = 8,
-}
-
-tile_pattern{
-  id = "table.10",
-  ground = "wall",
-  default_layer = 1,
-  x = 440,
-  y = 112,
-  width = 8,
-  height = 8,
-}
-
-tile_pattern{
-  id = "table.11",
-  ground = "wall",
-  default_layer = 1,
-  x = 456,
   y = 112,
   width = 8,
   height = 8,
@@ -5157,6 +5157,46 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "wall_pillar.10.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 432,
+  width = 16,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 224,
+  y = 432,
+  width = 16,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 480,
+  width = 32,
+  height = 16,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 464,
+  width = 32,
+  height = 16,
+}
+
+tile_pattern{
   id = "wall_pillar.2.1",
   ground = "wall",
   default_layer = 1,
@@ -5477,46 +5517,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "wall_pillar.10.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 432,
-  width = 16,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 224,
-  y = 432,
-  width = 16,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 480,
-  width = 32,
-  height = 16,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 464,
-  width = 32,
-  height = 16,
-}
-
-tile_pattern{
   id = "wall_pipe.1",
   ground = "wall",
   default_layer = 1,
@@ -5592,6 +5592,86 @@ tile_pattern{
   default_layer = 1,
   x = 272,
   y = 240,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.10.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 352,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.10.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 320,
+  y = 384,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.10.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 376,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.10.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 328,
+  y = 352,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.11.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 408,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.11.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 320,
+  y = 440,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.11.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 432,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.11.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 328,
+  y = 408,
   width = 24,
   height = 32,
 }
@@ -5912,86 +5992,6 @@ tile_pattern{
   default_layer = 1,
   x = 328,
   y = 296,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.10.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 352,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.10.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 320,
-  y = 384,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.10.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 376,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.10.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 328,
-  y = 352,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.11.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 408,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.11.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 320,
-  y = 440,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.11.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 432,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.11.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 328,
-  y = 408,
   width = 24,
   height = 32,
 }

--- a/data/tilesets/dungeon_ice_blue_1.dat
+++ b/data/tilesets/dungeon_ice_blue_1.dat
@@ -101,7 +101,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 40,
@@ -111,7 +111,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 40,
@@ -121,7 +121,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 40,
@@ -131,7 +131,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 88,
@@ -141,7 +141,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 88,
@@ -151,7 +151,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 88,
@@ -161,7 +161,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 80,
@@ -171,7 +171,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 80,
@@ -181,7 +181,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 80,
@@ -2100,86 +2100,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "floor.2",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 112,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.3",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 128,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.4",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 144,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.5",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 160,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.6",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 176,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.7",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 192,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.8",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 208,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.9",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 224,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
   id = "floor.10",
   ground = "traversable",
   default_layer = 1,
@@ -2275,6 +2195,16 @@ tile_pattern{
   default_layer = 1,
   x = 112,
   y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.2",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 112,
   width = 16,
   height = 16,
 }
@@ -2380,6 +2310,16 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "floor.3",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 128,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
   id = "floor.31",
   ground = "traversable",
   default_layer = 1,
@@ -2424,6 +2364,66 @@ tile_pattern{
   ground = "traversable",
   default_layer = 1,
   x = 240,
+  y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.4",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 144,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.5",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 160,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.6",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 176,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.7",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 192,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.8",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 208,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.9",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
   y = 224,
   width = 16,
   height = 16,
@@ -2560,86 +2560,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "floor_low.2",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 112,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.3",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 128,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.4",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 144,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.5",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 160,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.6",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 176,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.7",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 192,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.8",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 208,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.9",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 224,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
   id = "floor_low.10",
   ground = "traversable",
   default_layer = 0,
@@ -2730,6 +2650,16 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "floor_low.2",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 112,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
   id = "floor_low.25",
   ground = "traversable",
   default_layer = 1,
@@ -2774,6 +2704,16 @@ tile_pattern{
   ground = "traversable",
   default_layer = 0,
   x = 256,
+  y = 128,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.3",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
   y = 128,
   width = 16,
   height = 16,
@@ -2834,6 +2774,66 @@ tile_pattern{
   ground = "traversable",
   default_layer = 0,
   x = 256,
+  y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.4",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 144,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.5",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 160,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.6",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 176,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.7",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 192,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.8",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 208,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.9",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
   y = 224,
   width = 16,
   height = 16,
@@ -4147,6 +4147,26 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "table.10",
+  ground = "wall",
+  default_layer = 1,
+  x = 440,
+  y = 112,
+  width = 8,
+  height = 8,
+}
+
+tile_pattern{
+  id = "table.11",
+  ground = "wall",
+  default_layer = 1,
+  x = 456,
+  y = 112,
+  width = 8,
+  height = 8,
+}
+
+tile_pattern{
   id = "table.2",
   ground = "wall",
   default_layer = 1,
@@ -4221,26 +4241,6 @@ tile_pattern{
   ground = "wall",
   default_layer = 1,
   x = 432,
-  y = 112,
-  width = 8,
-  height = 8,
-}
-
-tile_pattern{
-  id = "table.10",
-  ground = "wall",
-  default_layer = 1,
-  x = 440,
-  y = 112,
-  width = 8,
-  height = 8,
-}
-
-tile_pattern{
-  id = "table.11",
-  ground = "wall",
-  default_layer = 1,
-  x = 456,
   y = 112,
   width = 8,
   height = 8,
@@ -5157,6 +5157,46 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "wall_pillar.10.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 432,
+  width = 16,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 224,
+  y = 432,
+  width = 16,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 480,
+  width = 32,
+  height = 16,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 464,
+  width = 32,
+  height = 16,
+}
+
+tile_pattern{
   id = "wall_pillar.2.1",
   ground = "wall",
   default_layer = 1,
@@ -5477,46 +5517,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "wall_pillar.10.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 432,
-  width = 16,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 224,
-  y = 432,
-  width = 16,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 480,
-  width = 32,
-  height = 16,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 464,
-  width = 32,
-  height = 16,
-}
-
-tile_pattern{
   id = "wall_pipe.1",
   ground = "wall",
   default_layer = 1,
@@ -5592,6 +5592,86 @@ tile_pattern{
   default_layer = 1,
   x = 272,
   y = 240,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.10.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 352,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.10.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 320,
+  y = 384,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.10.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 376,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.10.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 328,
+  y = 352,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.11.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 408,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.11.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 320,
+  y = 440,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.11.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 432,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.11.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 328,
+  y = 408,
   width = 24,
   height = 32,
 }
@@ -5912,86 +5992,6 @@ tile_pattern{
   default_layer = 1,
   x = 328,
   y = 296,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.10.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 352,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.10.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 320,
-  y = 384,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.10.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 376,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.10.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 328,
-  y = 352,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.11.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 408,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.11.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 320,
-  y = 440,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.11.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 432,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.11.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 328,
-  y = 408,
   width = 24,
   height = 32,
 }

--- a/data/tilesets/dungeon_smoothbrick_brown_1.dat
+++ b/data/tilesets/dungeon_smoothbrick_brown_1.dat
@@ -101,7 +101,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 40,
@@ -111,7 +111,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 40,
@@ -121,7 +121,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 40,
@@ -131,7 +131,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 88,
@@ -141,7 +141,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 88,
@@ -151,7 +151,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 88,
@@ -161,7 +161,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 80,
@@ -171,7 +171,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 80,
@@ -181,7 +181,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 80,
@@ -2100,86 +2100,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "floor.2",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 112,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.3",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 128,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.4",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 144,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.5",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 160,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.6",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 176,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.7",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 192,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.8",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 208,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.9",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 224,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
   id = "floor.10",
   ground = "traversable",
   default_layer = 1,
@@ -2275,6 +2195,16 @@ tile_pattern{
   default_layer = 1,
   x = 112,
   y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.2",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 112,
   width = 16,
   height = 16,
 }
@@ -2380,6 +2310,16 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "floor.3",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 128,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
   id = "floor.31",
   ground = "traversable",
   default_layer = 1,
@@ -2424,6 +2364,66 @@ tile_pattern{
   ground = "traversable",
   default_layer = 1,
   x = 240,
+  y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.4",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 144,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.5",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 160,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.6",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 176,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.7",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 192,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.8",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 208,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.9",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
   y = 224,
   width = 16,
   height = 16,
@@ -2560,86 +2560,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "floor_low.2",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 112,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.3",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 128,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.4",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 144,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.5",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 160,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.6",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 176,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.7",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 192,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.8",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 208,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.9",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 224,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
   id = "floor_low.10",
   ground = "traversable",
   default_layer = 0,
@@ -2730,6 +2650,16 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "floor_low.2",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 112,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
   id = "floor_low.25",
   ground = "traversable",
   default_layer = 1,
@@ -2774,6 +2704,16 @@ tile_pattern{
   ground = "traversable",
   default_layer = 0,
   x = 256,
+  y = 128,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.3",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
   y = 128,
   width = 16,
   height = 16,
@@ -2834,6 +2774,66 @@ tile_pattern{
   ground = "traversable",
   default_layer = 0,
   x = 256,
+  y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.4",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 144,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.5",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 160,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.6",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 176,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.7",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 192,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.8",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 208,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.9",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
   y = 224,
   width = 16,
   height = 16,
@@ -4147,6 +4147,26 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "table.10",
+  ground = "wall",
+  default_layer = 1,
+  x = 440,
+  y = 112,
+  width = 8,
+  height = 8,
+}
+
+tile_pattern{
+  id = "table.11",
+  ground = "wall",
+  default_layer = 1,
+  x = 456,
+  y = 112,
+  width = 8,
+  height = 8,
+}
+
+tile_pattern{
   id = "table.2",
   ground = "wall",
   default_layer = 1,
@@ -4221,26 +4241,6 @@ tile_pattern{
   ground = "wall",
   default_layer = 1,
   x = 432,
-  y = 112,
-  width = 8,
-  height = 8,
-}
-
-tile_pattern{
-  id = "table.10",
-  ground = "wall",
-  default_layer = 1,
-  x = 440,
-  y = 112,
-  width = 8,
-  height = 8,
-}
-
-tile_pattern{
-  id = "table.11",
-  ground = "wall",
-  default_layer = 1,
-  x = 456,
   y = 112,
   width = 8,
   height = 8,
@@ -5157,6 +5157,46 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "wall_pillar.10.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 432,
+  width = 16,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 224,
+  y = 432,
+  width = 16,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 480,
+  width = 32,
+  height = 16,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 464,
+  width = 32,
+  height = 16,
+}
+
+tile_pattern{
   id = "wall_pillar.2.1",
   ground = "wall",
   default_layer = 1,
@@ -5477,46 +5517,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "wall_pillar.10.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 432,
-  width = 16,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 224,
-  y = 432,
-  width = 16,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 480,
-  width = 32,
-  height = 16,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 464,
-  width = 32,
-  height = 16,
-}
-
-tile_pattern{
   id = "wall_pipe.1",
   ground = "wall",
   default_layer = 1,
@@ -5592,6 +5592,86 @@ tile_pattern{
   default_layer = 1,
   x = 272,
   y = 240,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.10.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 352,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.10.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 320,
+  y = 384,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.10.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 376,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.10.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 328,
+  y = 352,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.11.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 408,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.11.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 320,
+  y = 440,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.11.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 432,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.11.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 328,
+  y = 408,
   width = 24,
   height = 32,
 }
@@ -5912,86 +5992,6 @@ tile_pattern{
   default_layer = 1,
   x = 328,
   y = 296,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.10.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 352,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.10.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 320,
-  y = 384,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.10.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 376,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.10.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 328,
-  y = 352,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.11.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 408,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.11.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 320,
-  y = 440,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.11.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 432,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.11.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 328,
-  y = 408,
   width = 24,
   height = 32,
 }

--- a/data/tilesets/dungeon_smoothbrick_gold_1.dat
+++ b/data/tilesets/dungeon_smoothbrick_gold_1.dat
@@ -101,7 +101,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 40,
@@ -111,7 +111,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 40,
@@ -121,7 +121,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 40,
@@ -131,7 +131,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 88,
@@ -141,7 +141,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 88,
@@ -151,7 +151,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 88,
@@ -161,7 +161,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 80,
@@ -171,7 +171,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 80,
@@ -181,7 +181,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 80,
@@ -2100,86 +2100,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "floor.2",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 112,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.3",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 128,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.4",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 144,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.5",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 160,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.6",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 176,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.7",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 192,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.8",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 208,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.9",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 224,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
   id = "floor.10",
   ground = "traversable",
   default_layer = 1,
@@ -2275,6 +2195,16 @@ tile_pattern{
   default_layer = 1,
   x = 112,
   y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.2",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 112,
   width = 16,
   height = 16,
 }
@@ -2380,6 +2310,16 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "floor.3",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 128,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
   id = "floor.31",
   ground = "traversable",
   default_layer = 1,
@@ -2424,6 +2364,66 @@ tile_pattern{
   ground = "traversable",
   default_layer = 1,
   x = 240,
+  y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.4",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 144,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.5",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 160,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.6",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 176,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.7",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 192,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.8",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 208,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.9",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
   y = 224,
   width = 16,
   height = 16,
@@ -2560,86 +2560,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "floor_low.2",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 112,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.3",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 128,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.4",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 144,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.5",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 160,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.6",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 176,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.7",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 192,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.8",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 208,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.9",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 224,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
   id = "floor_low.10",
   ground = "traversable",
   default_layer = 0,
@@ -2730,6 +2650,16 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "floor_low.2",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 112,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
   id = "floor_low.25",
   ground = "traversable",
   default_layer = 1,
@@ -2774,6 +2704,16 @@ tile_pattern{
   ground = "traversable",
   default_layer = 0,
   x = 256,
+  y = 128,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.3",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
   y = 128,
   width = 16,
   height = 16,
@@ -2834,6 +2774,66 @@ tile_pattern{
   ground = "traversable",
   default_layer = 0,
   x = 256,
+  y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.4",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 144,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.5",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 160,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.6",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 176,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.7",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 192,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.8",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 208,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.9",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
   y = 224,
   width = 16,
   height = 16,
@@ -4147,6 +4147,26 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "table.10",
+  ground = "wall",
+  default_layer = 1,
+  x = 440,
+  y = 112,
+  width = 8,
+  height = 8,
+}
+
+tile_pattern{
+  id = "table.11",
+  ground = "wall",
+  default_layer = 1,
+  x = 456,
+  y = 112,
+  width = 8,
+  height = 8,
+}
+
+tile_pattern{
   id = "table.2",
   ground = "wall",
   default_layer = 1,
@@ -4221,26 +4241,6 @@ tile_pattern{
   ground = "wall",
   default_layer = 1,
   x = 432,
-  y = 112,
-  width = 8,
-  height = 8,
-}
-
-tile_pattern{
-  id = "table.10",
-  ground = "wall",
-  default_layer = 1,
-  x = 440,
-  y = 112,
-  width = 8,
-  height = 8,
-}
-
-tile_pattern{
-  id = "table.11",
-  ground = "wall",
-  default_layer = 1,
-  x = 456,
   y = 112,
   width = 8,
   height = 8,
@@ -5157,6 +5157,46 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "wall_pillar.10.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 432,
+  width = 16,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 224,
+  y = 432,
+  width = 16,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 480,
+  width = 32,
+  height = 16,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 464,
+  width = 32,
+  height = 16,
+}
+
+tile_pattern{
   id = "wall_pillar.2.1",
   ground = "wall",
   default_layer = 1,
@@ -5477,46 +5517,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "wall_pillar.10.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 432,
-  width = 16,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 224,
-  y = 432,
-  width = 16,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 480,
-  width = 32,
-  height = 16,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 464,
-  width = 32,
-  height = 16,
-}
-
-tile_pattern{
   id = "wall_pipe.1",
   ground = "wall",
   default_layer = 1,
@@ -5592,6 +5592,86 @@ tile_pattern{
   default_layer = 1,
   x = 272,
   y = 240,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.10.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 352,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.10.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 320,
+  y = 384,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.10.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 376,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.10.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 328,
+  y = 352,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.11.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 408,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.11.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 320,
+  y = 440,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.11.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 432,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.11.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 328,
+  y = 408,
   width = 24,
   height = 32,
 }
@@ -5912,86 +5992,6 @@ tile_pattern{
   default_layer = 1,
   x = 328,
   y = 296,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.10.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 352,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.10.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 320,
-  y = 384,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.10.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 376,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.10.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 328,
-  y = 352,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.11.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 408,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.11.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 320,
-  y = 440,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.11.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 432,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.11.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 328,
-  y = 408,
   width = 24,
   height = 32,
 }

--- a/data/tilesets/dungeon_smoothbrick_green_1.dat
+++ b/data/tilesets/dungeon_smoothbrick_green_1.dat
@@ -101,7 +101,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 40,
@@ -111,7 +111,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 40,
@@ -121,7 +121,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 40,
@@ -131,7 +131,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 88,
@@ -141,7 +141,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 88,
@@ -151,7 +151,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 88,
@@ -161,7 +161,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 80,
@@ -171,7 +171,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 80,
@@ -181,7 +181,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 80,
@@ -2100,86 +2100,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "floor.2",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 112,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.3",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 128,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.4",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 144,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.5",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 160,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.6",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 176,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.7",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 192,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.8",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 208,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.9",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 224,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
   id = "floor.10",
   ground = "traversable",
   default_layer = 1,
@@ -2275,6 +2195,16 @@ tile_pattern{
   default_layer = 1,
   x = 112,
   y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.2",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 112,
   width = 16,
   height = 16,
 }
@@ -2380,6 +2310,16 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "floor.3",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 128,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
   id = "floor.31",
   ground = "traversable",
   default_layer = 1,
@@ -2424,6 +2364,66 @@ tile_pattern{
   ground = "traversable",
   default_layer = 1,
   x = 240,
+  y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.4",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 144,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.5",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 160,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.6",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 176,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.7",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 192,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.8",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 208,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.9",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
   y = 224,
   width = 16,
   height = 16,
@@ -2560,86 +2560,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "floor_low.2",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 112,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.3",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 128,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.4",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 144,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.5",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 160,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.6",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 176,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.7",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 192,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.8",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 208,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.9",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 224,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
   id = "floor_low.10",
   ground = "traversable",
   default_layer = 0,
@@ -2730,6 +2650,16 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "floor_low.2",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 112,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
   id = "floor_low.25",
   ground = "traversable",
   default_layer = 1,
@@ -2774,6 +2704,16 @@ tile_pattern{
   ground = "traversable",
   default_layer = 0,
   x = 256,
+  y = 128,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.3",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
   y = 128,
   width = 16,
   height = 16,
@@ -2834,6 +2774,66 @@ tile_pattern{
   ground = "traversable",
   default_layer = 0,
   x = 256,
+  y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.4",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 144,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.5",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 160,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.6",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 176,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.7",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 192,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.8",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 208,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.9",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
   y = 224,
   width = 16,
   height = 16,
@@ -4147,6 +4147,26 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "table.10",
+  ground = "wall",
+  default_layer = 1,
+  x = 440,
+  y = 112,
+  width = 8,
+  height = 8,
+}
+
+tile_pattern{
+  id = "table.11",
+  ground = "wall",
+  default_layer = 1,
+  x = 456,
+  y = 112,
+  width = 8,
+  height = 8,
+}
+
+tile_pattern{
   id = "table.2",
   ground = "wall",
   default_layer = 1,
@@ -4221,26 +4241,6 @@ tile_pattern{
   ground = "wall",
   default_layer = 1,
   x = 432,
-  y = 112,
-  width = 8,
-  height = 8,
-}
-
-tile_pattern{
-  id = "table.10",
-  ground = "wall",
-  default_layer = 1,
-  x = 440,
-  y = 112,
-  width = 8,
-  height = 8,
-}
-
-tile_pattern{
-  id = "table.11",
-  ground = "wall",
-  default_layer = 1,
-  x = 456,
   y = 112,
   width = 8,
   height = 8,
@@ -5157,6 +5157,46 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "wall_pillar.10.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 432,
+  width = 16,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 224,
+  y = 432,
+  width = 16,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 480,
+  width = 32,
+  height = 16,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 464,
+  width = 32,
+  height = 16,
+}
+
+tile_pattern{
   id = "wall_pillar.2.1",
   ground = "wall",
   default_layer = 1,
@@ -5477,46 +5517,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "wall_pillar.10.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 432,
-  width = 16,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 224,
-  y = 432,
-  width = 16,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 480,
-  width = 32,
-  height = 16,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 464,
-  width = 32,
-  height = 16,
-}
-
-tile_pattern{
   id = "wall_pipe.1",
   ground = "wall",
   default_layer = 1,
@@ -5592,6 +5592,86 @@ tile_pattern{
   default_layer = 1,
   x = 272,
   y = 240,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.10.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 352,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.10.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 320,
+  y = 384,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.10.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 376,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.10.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 328,
+  y = 352,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.11.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 408,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.11.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 320,
+  y = 440,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.11.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 432,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.11.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 328,
+  y = 408,
   width = 24,
   height = 32,
 }
@@ -5912,86 +5992,6 @@ tile_pattern{
   default_layer = 1,
   x = 328,
   y = 296,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.10.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 352,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.10.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 320,
-  y = 384,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.10.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 376,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.10.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 328,
-  y = 352,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.11.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 408,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.11.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 320,
-  y = 440,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.11.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 432,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.11.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 328,
-  y = 408,
   width = 24,
   height = 32,
 }

--- a/data/tilesets/dungeon_smoothbrick_pink_1.dat
+++ b/data/tilesets/dungeon_smoothbrick_pink_1.dat
@@ -101,7 +101,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 40,
@@ -111,7 +111,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 40,
@@ -121,7 +121,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.1.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 40,
@@ -131,7 +131,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 88,
@@ -141,7 +141,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 88,
@@ -151,7 +151,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.2.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 88,
@@ -161,7 +161,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.1",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 56,
   y = 80,
@@ -171,7 +171,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.2",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 64,
   y = 80,
@@ -181,7 +181,7 @@ tile_pattern{
 
 tile_pattern{
   id = "barrier.3.border",
-  ground = "wall",
+  ground = "low_wall",
   default_layer = 1,
   x = 48,
   y = 80,
@@ -2100,86 +2100,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "floor.2",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 112,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.3",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 128,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.4",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 144,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.5",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 160,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.6",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 176,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.7",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 192,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.8",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 208,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor.9",
-  ground = "traversable",
-  default_layer = 1,
-  x = 208,
-  y = 224,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
   id = "floor.10",
   ground = "traversable",
   default_layer = 1,
@@ -2275,6 +2195,16 @@ tile_pattern{
   default_layer = 1,
   x = 112,
   y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.2",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 112,
   width = 16,
   height = 16,
 }
@@ -2380,6 +2310,16 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "floor.3",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 128,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
   id = "floor.31",
   ground = "traversable",
   default_layer = 1,
@@ -2424,6 +2364,66 @@ tile_pattern{
   ground = "traversable",
   default_layer = 1,
   x = 240,
+  y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.4",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 144,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.5",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 160,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.6",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 176,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.7",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 192,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.8",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
+  y = 208,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor.9",
+  ground = "traversable",
+  default_layer = 1,
+  x = 208,
   y = 224,
   width = 16,
   height = 16,
@@ -2560,86 +2560,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "floor_low.2",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 112,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.3",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 128,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.4",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 144,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.5",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 160,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.6",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 176,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.7",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 192,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.8",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 208,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
-  id = "floor_low.9",
-  ground = "traversable",
-  default_layer = 0,
-  x = 224,
-  y = 224,
-  width = 16,
-  height = 16,
-}
-
-tile_pattern{
   id = "floor_low.10",
   ground = "traversable",
   default_layer = 0,
@@ -2730,6 +2650,16 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "floor_low.2",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 112,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
   id = "floor_low.25",
   ground = "traversable",
   default_layer = 1,
@@ -2774,6 +2704,16 @@ tile_pattern{
   ground = "traversable",
   default_layer = 0,
   x = 256,
+  y = 128,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.3",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
   y = 128,
   width = 16,
   height = 16,
@@ -2834,6 +2774,66 @@ tile_pattern{
   ground = "traversable",
   default_layer = 0,
   x = 256,
+  y = 224,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.4",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 144,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.5",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 160,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.6",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 176,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.7",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 192,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.8",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
+  y = 208,
+  width = 16,
+  height = 16,
+}
+
+tile_pattern{
+  id = "floor_low.9",
+  ground = "traversable",
+  default_layer = 0,
+  x = 224,
   y = 224,
   width = 16,
   height = 16,
@@ -4147,6 +4147,26 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "table.10",
+  ground = "wall",
+  default_layer = 1,
+  x = 440,
+  y = 112,
+  width = 8,
+  height = 8,
+}
+
+tile_pattern{
+  id = "table.11",
+  ground = "wall",
+  default_layer = 1,
+  x = 456,
+  y = 112,
+  width = 8,
+  height = 8,
+}
+
+tile_pattern{
   id = "table.2",
   ground = "wall",
   default_layer = 1,
@@ -4221,26 +4241,6 @@ tile_pattern{
   ground = "wall",
   default_layer = 1,
   x = 432,
-  y = 112,
-  width = 8,
-  height = 8,
-}
-
-tile_pattern{
-  id = "table.10",
-  ground = "wall",
-  default_layer = 1,
-  x = 440,
-  y = 112,
-  width = 8,
-  height = 8,
-}
-
-tile_pattern{
-  id = "table.11",
-  ground = "wall",
-  default_layer = 1,
-  x = 456,
   y = 112,
   width = 8,
   height = 8,
@@ -5157,6 +5157,46 @@ tile_pattern{
 }
 
 tile_pattern{
+  id = "wall_pillar.10.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 432,
+  width = 16,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 224,
+  y = 432,
+  width = 16,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 480,
+  width = 32,
+  height = 16,
+}
+
+tile_pattern{
+  id = "wall_pillar.10.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 208,
+  y = 464,
+  width = 32,
+  height = 16,
+}
+
+tile_pattern{
   id = "wall_pillar.2.1",
   ground = "wall",
   default_layer = 1,
@@ -5477,46 +5517,6 @@ tile_pattern{
 }
 
 tile_pattern{
-  id = "wall_pillar.10.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 432,
-  width = 16,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 224,
-  y = 432,
-  width = 16,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 480,
-  width = 32,
-  height = 16,
-}
-
-tile_pattern{
-  id = "wall_pillar.10.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 208,
-  y = 464,
-  width = 32,
-  height = 16,
-}
-
-tile_pattern{
   id = "wall_pipe.1",
   ground = "wall",
   default_layer = 1,
@@ -5592,6 +5592,86 @@ tile_pattern{
   default_layer = 1,
   x = 272,
   y = 240,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.10.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 352,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.10.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 320,
+  y = 384,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.10.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 376,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.10.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 328,
+  y = 352,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.11.1",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 408,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.11.2",
+  ground = "wall",
+  default_layer = 1,
+  x = 320,
+  y = 440,
+  width = 32,
+  height = 24,
+}
+
+tile_pattern{
+  id = "wall_statue.11.3",
+  ground = "wall",
+  default_layer = 1,
+  x = 296,
+  y = 432,
+  width = 24,
+  height = 32,
+}
+
+tile_pattern{
+  id = "wall_statue.11.4",
+  ground = "wall",
+  default_layer = 1,
+  x = 328,
+  y = 408,
   width = 24,
   height = 32,
 }
@@ -5912,86 +5992,6 @@ tile_pattern{
   default_layer = 1,
   x = 328,
   y = 296,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.10.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 352,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.10.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 320,
-  y = 384,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.10.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 376,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.10.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 328,
-  y = 352,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.11.1",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 408,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.11.2",
-  ground = "wall",
-  default_layer = 1,
-  x = 320,
-  y = 440,
-  width = 32,
-  height = 24,
-}
-
-tile_pattern{
-  id = "wall_statue.11.3",
-  ground = "wall",
-  default_layer = 1,
-  x = 296,
-  y = 432,
-  width = 24,
-  height = 32,
-}
-
-tile_pattern{
-  id = "wall_statue.11.4",
-  ground = "wall",
-  default_layer = 1,
-  x = 328,
-  y = 408,
   width = 24,
   height = 32,
 }


### PR DESCRIPTION
Fixes #77 
The fix seems to be orthogonal to the Solarus 1.4 migration.
