### PR TITLE
Bounce enemies away from appearing chests

### DIFF
--- a/data/lib/entity_mixin.lua
+++ b/data/lib/entity_mixin.lua
@@ -38,6 +38,73 @@ function entity_mixin.mixin(mt)
         return directions[bits]
     end
 
+    function mt:bounce_enemies()
+        self_x, self_y = self:get_position()
+        self_ox, self_oy = self:get_origin()
+        self_w, self_h = self:get_size()
+
+        to_kill = {}
+        for enemy in self:get_map():get_entities('') do
+            if enemy:get_type() == 'enemy' and enemy:overlaps(self) then
+                enemy_x, enemy_y = enemy:get_position()
+                enemy_ox, enemy_oy = enemy:get_origin()
+                enemy_w, enemy_h = enemy:get_size()
+
+                if enemy_x == self_x and enemy_y == self_y then
+                    enemy_dx = 0
+                    enemy_dy = 0
+                elseif enemy_x == self_x then
+                    if enemy_y < self_y then
+                        enemy_yb = self_y - self_oy - enemy_h + enemy_oy
+                    else
+                        enemy_yb = self_y - self_oy + self_h + enemy_oy
+                    end
+                    enemy_dx = 0
+                    enemy_dy = enemy_yb - enemy_y
+                elseif enemy_y == self_y then
+                    if enemy_x < self_x then
+                        enemy_xb = self_x - self_ox - enemy_w + enemy_ox
+                    else
+                        enemy_xb = self_x - self_ox + self_w + enemy_ox
+                    end
+                    enemy_dx = enemy_xb - enemy_x
+                    enemy_dy = 0
+                else
+                    if enemy_x < self_x then
+                        enemy_xa = self_x - self_ox - enemy_w + enemy_ox
+                    else
+                        enemy_xa = self_x - self_ox + self_w + enemy_ox
+                    end
+                    enemy_dxa = enemy_xa - enemy_x
+                    enemy_dya = math.floor(enemy_dxa * (enemy_y - self_y) / (enemy_x - self_x) + 0.5)
+
+                    if enemy_y < self_y then
+                        enemy_yb = self_y - self_oy - enemy_h + enemy_oy
+                    else
+                        enemy_yb = self_y - self_oy + self_h + enemy_oy
+                    end
+                    enemy_dyb = enemy_yb - enemy_y
+                    enemy_dxb = math.floor(enemy_dyb * (enemy_x - self_x) / (enemy_y - self_y) + 0.5)
+
+                    if enemy_dxa * enemy_dxa + enemy_dya * enemy_dya <= enemy_dyb * enemy_dyb + enemy_dxb * enemy_dxb then
+                        enemy_dx = enemy_dxa
+                        enemy_dy = enemy_dya
+                    else
+                        enemy_dx = enemy_dxb
+                        enemy_dy = enemy_dyb
+                    end
+                end
+
+                if enemy:test_obstacles(enemy_dx, enemy_dy) then
+                    enemy:set_life(0)
+                else
+                    enemy:set_position(enemy_x + enemy_dx, enemy_y + enemy_dy - 1)
+                    enemy:restart() -- work around solarus bug (fixed in 1.5)
+                end
+            end
+        end
+    end
+
 end
 
 return entity_mixin

--- a/data/main.lua
+++ b/data/main.lua
@@ -16,6 +16,7 @@ function sol.main:on_started()
     end
 
     entity_mixin.mixin(sol.main.get_metatable('enemy'))
+    entity_mixin.mixin(sol.main.get_metatable('chest'))
     bindings.mixin(solarus_logo)
     bindings.mixin(legofarmen_logo)
     bindings.mixin(title_screen)

--- a/data/maps/components/obstacle_bow/obstacle_bow.lua
+++ b/data/maps/components/obstacle_bow/obstacle_bow.lua
@@ -48,6 +48,13 @@ function bow.init(map, data, timeout)
         if data.treasure1 then
             hidden_chest:set_enabled(true)
             sound = 'chest_appears'
+            sol.timer.start(100, function ()
+                if hidden_chest:is_enabled() then
+                    hidden_chest:bounce_enemies()
+                else
+                    return true
+                end
+            end)
         end
         for _, component in ipairs(doors) do
             component:open()

--- a/data/maps/components/obstacle_lamp/obstacle_lamp.lua
+++ b/data/maps/components/obstacle_lamp/obstacle_lamp.lua
@@ -54,6 +54,13 @@ function lamp.init(map, data, timeout)
                 if data.treasure1 then
                     hidden_chest:set_enabled(true)
                     sound = 'chest_appears'
+                    sol.timer.start(100, function ()
+                        if hidden_chest:is_enabled() then
+                            hidden_chest:bounce_enemies()
+                        else
+                            return true
+                        end
+                    end)
                 end
                 for _, component in ipairs(doors) do
                     component:open()

--- a/data/maps/components/obstacle_puzzle/obstacle_puzzle.lua
+++ b/data/maps/components/obstacle_puzzle/obstacle_puzzle.lua
@@ -80,6 +80,13 @@ function puzzle.init(map, data)
             if data.treasure1 then
                 hidden_chest:set_enabled(true)
                 sound = 'chest_appears'
+                sol.timer.start(100, function ()
+                    if hidden_chest:is_enabled() then
+                        hidden_chest:bounce_enemies()
+                    else
+                        return true
+                    end
+                end)
             end
             for _, component in ipairs(doors) do
                 component:open()


### PR DESCRIPTION
Fixes #27.
To ease debugging I've tailored a test case that I'm providing in the https://github.com/mattias-p/tunics/tree/stuck-debug branch. For some reason Solarus 1.3 and 1.4 ends up generating different levels for the same seed, and the test case only works with 1.4. Moreover, the test case only focuses on puzzle obstacles. This PR applies the same behavior for both bow and lamp obstacles as well. However, I don't have special test cases for those.
