### PR TITLE
Fix loading closed door in open state

### DIFF
--- a/data/maps/components/door/door_closed.lua
+++ b/data/maps/components/door/door_closed.lua
@@ -51,6 +51,10 @@ function door_closed.init(map, data, direction4)
         map:remove_entities('entering')
     end
 
+    if door:is_open() then
+        door:on_opened()
+    end
+
     return component
 end
 


### PR DESCRIPTION
When you enter a "closed" door from the open end, it will push you into the room and close the door behind you. When the door is opened the pushing is disabled. If you save and load the game, the door stays open but the pushing mechanism is re-enabled.

This change makes sure the pushing mechanism is disabled for open "closed" door at load time.